### PR TITLE
Fix failure callback to pass Throwable object instead of string

### DIFF
--- a/src/DocblockAnnotator.php
+++ b/src/DocblockAnnotator.php
@@ -118,7 +118,7 @@ class DocblockAnnotator extends NodeVisitorAbstract
                 }
             } catch (Throwable $throwable) {
                 if ($this->failure) {
-                    ($this->failure)($throwable->getMessage());
+                    ($this->failure)($throwable);
                 } else {
                     throw $throwable;
                 }


### PR DESCRIPTION
## Description

Fix failure callback to pass Throwable object instead of string   

- Update DocblockAnnotator to pass the full Throwable object to failure callbacks instead of just the message string
- Fix TypeError that occurred when failure callbacks expected Throwable parameter but received string
- Update existing test to work with new Throwable parameter signature
- Add test to verify failure callback receives Throwable object with proper error details